### PR TITLE
Fix WebSocket doc name

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -14,7 +14,7 @@ const server = http.createServer((request, response) => {
 const wss = new WebSocket.Server({ server })
 
 wss.on('connection', (conn, req) => {
-  setupWSConnection(conn, req, { docName: 'collaborative-hockey-app' })
+  setupWSConnection(conn, req)
   console.log('Cliente conectado:', new Date().toLocaleTimeString())
 })
 


### PR DESCRIPTION
## Summary
- remove hardcoded docName in server.cjs so clients join expected rooms

## Testing
- `npm run lint` *(fails: ES2015 module syntax is preferred over namespaces)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840ad34f9d88329838d1ff2bd6e5e24